### PR TITLE
feat: reset robot from random EE position in workspace

### DIFF
--- a/source/isaaclab/isaaclab/envs/mdp/events.py
+++ b/source/isaaclab/isaaclab/envs/mdp/events.py
@@ -32,7 +32,7 @@ from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 from isaaclab.terrains import TerrainImporter
 
 if TYPE_CHECKING:
-    from isaaclab.envs import ManagerBasedEnv
+    from isaaclab.envs import ManagerBasedEnv, ManagerBasedRLEnv
 
 
 def randomize_rigid_body_scale(
@@ -1091,6 +1091,87 @@ def reset_joints_by_offset(
     # set into the physics simulation
     asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
 
+def reset_robot_by_ee_pose(
+    env: ManagerBasedRLEnv,
+    env_ids: torch.Tensor,
+    x_range: tuple[float, float],
+    y_range: tuple[float, float],
+    z_range: tuple[float, float],
+    ee_frame_name: str,
+    arm_joint_names: list[str],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    lambda_val: float = 0.01,
+    max_inverse_kinematics_iterations: int = 50,
+    position_error_threshold: float = 1e-6,
+):
+    """Reset the robot joints by setting the end-effector pose to a random value within the given ranges.
+    This function samples random values from the given ranges and sets the end-effector pose of the robot to these values.
+    The end-effector pose is defined by the position and orientation of the end-effector in the world frame.
+    The function then computes the joint positions and velocities that achieve this end-effector pose and sets them
+    into the physics simulation.
+    """
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    end_effector_jacobian_index = asset.find_bodies(ee_frame_name)[0][0] - 1 
+    arm_joint_ids = asset.find_joints(arm_joint_names)[0]
+
+    # sample random end-effector pose
+    num_envs = len(env_ids)
+
+    # Fill position
+    target_pos_b = torch.empty((num_envs, 3), device=asset.device)    
+    target_pos_b[:, 0] = torch.empty(num_envs, device=asset.device).uniform_(*x_range)
+    target_pos_b[:, 1] = torch.empty(num_envs, device=asset.device).uniform_(*y_range)
+    target_pos_b[:, 2] = torch.empty(num_envs, device=asset.device).uniform_(*z_range)
+
+    solving = torch.ones(len(env_ids), dtype=torch.bool, device=asset.device)
+
+    for index in range(max_inverse_kinematics_iterations):
+        if index == 0:
+            target_joint_pos = asset.data.default_joint_pos.clone()[env_ids][:, arm_joint_ids]
+        else:
+            root_pos_w = asset.data.root_pos_w[env_ids]
+            root_quat_w = asset.data.root_quat_w[env_ids]
+
+            joint_pos = asset.data.joint_pos[env_ids][:, arm_joint_ids]
+            ee_pos_w  = asset.data.body_link_pos_w[env_ids][:, end_effector_jacobian_index, :].squeeze(1)
+            ee_pos_b = ee_pos_w - root_pos_w
+
+            position_error = target_pos_b - ee_pos_b
+            pos_error_norm = position_error.norm(dim=-1)
+            solving = (pos_error_norm >= position_error_threshold)
+            if not solving.any():
+                break
+
+            solving_index = solving.nonzero(as_tuple=False).squeeze(-1)
+            jacobian = asset.root_physx_view.get_jacobians()[env_ids][:, end_effector_jacobian_index, 0:3, arm_joint_ids][
+                solving_index
+            ]
+            base_rot_matrix = math_utils.matrix_from_quat(math_utils.quat_inv(root_quat_w[solving_index]))
+            jacobian_base = jacobian.clone()
+            jacobian_base = torch.bmm(base_rot_matrix, jacobian)
+            jacobian_base_transpose = torch.transpose(jacobian_base, dim0=1, dim1=2)
+            lambda_matrix = (lambda_val**2) + torch.eye(n=jacobian_base.shape[1], device=asset.device)
+
+            delta_joint_pos = torch.zeros_like(joint_pos, device=asset.device)
+            delta_joint_pos[solving_index] = (jacobian_base_transpose @ torch.inverse(jacobian_base @ jacobian_base_transpose + lambda_matrix) @ position_error[solving_index].unsqueeze(-1)).squeeze(-1)
+
+            target_joint_pos = joint_pos + delta_joint_pos
+            joint_pos_limits = asset.data.soft_joint_pos_limits[env_ids][:, arm_joint_ids]
+
+            target_joint_pos = target_joint_pos.clamp(joint_pos_limits[..., 0], joint_pos_limits[..., 1])
+
+        asset.write_joint_state_to_sim(
+            target_joint_pos,
+            torch.zeros_like(target_joint_pos, device=asset.device),  # velocities are set to zero
+            joint_ids=arm_joint_ids,
+            env_ids=env_ids,  # type: ignore
+        )
+
+        # Invalidate timestamps so consequent call update the kinematics, in case needed
+        asset.data._joint_pos.timestamp = -1 # type: ignore
+        asset.data._body_link_pose_w.timestamp = -1 # type: ignore
 
 def reset_nodal_state_uniform(
     env: ManagerBasedEnv,


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #55 

<!-- Required: explain how the PR addresses the parent issue -->
This PR addresses the issue by introducing a new event function that iteratively calls the IK solver to reach target positions sampled from a uniform distribution, with the sampling range provided as a function input. This allows users to define the range of starting positions for the robot.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 3 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->